### PR TITLE
feat: AtCoderのジャッジアップデートの対応

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -294,23 +294,17 @@ export function activate(context: vscode.ExtensionContext) {
                     return;
                 }
                 // select language
-                let languages = acts.xsite.xlanguages.filter(val => val.xextension.extension === acts.xsite.extension).map(val => val.language);
-                languages = extensionhelper.moveToHead(languages, acts.xsite.language);
-                vscode.window
-                    .showQuickPick(languages, {
-                        placeHolder: "SELECT LANGUAGE",
-                    })
-                    .then(language => {
-                        if (language === undefined) {
-                            return;
-                        }
-                        // save site depending data
-                        acts.xsite.language = language;
-                        // exec command
-                        acts.submitTaskAsync().catch(ex => {
-                            acts.channel.appendLine("**** " + ex + " ****");
-                        });
-                    });
+                let xlanguages = acts.xsite.xlanguages.filter(val => val.xextension.extension === acts.xsite.extension);
+                if (acts.site === atcoder.site) {
+                    // check valid language ids
+                    atcoder.filterXLanguagesAsync(xlanguages)
+                        .then(filterxlanguages => {
+                            extensionhelper.selectLanguageSubmitTaskAsync(filterxlanguages);
+                        })
+                        .catch(ex => {acts.channel.appendLine("**** " + ex + " ****");});
+                } else {
+                    extensionhelper.selectLanguageSubmitTaskAsync(xlanguages);
+                }
             })
         );
     })();

--- a/src/extensionHelper.ts
+++ b/src/extensionHelper.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import { acts } from "./AcTsExtension";
+import { XLanguage } from "./XLanguage";
 
 // extension helper
 class ExtensionHelper {
@@ -64,6 +65,25 @@ class ExtensionHelper {
             dstarr.unshift(val);
         }
         return dstarr;
+    }
+
+    public async selectLanguageSubmitTaskAsync(xlanguages: XLanguage[]) {
+        let languages = this.moveToHead(xlanguages.map(val => val.language), acts.xsite.language);
+        vscode.window
+            .showQuickPick(languages, {
+                placeHolder: "SELECT LANGUAGE",
+            })
+            .then(language => {
+                if (language === undefined) {
+                    return;
+                }
+                // save site depending data
+                acts.xsite.language = language;
+                // exec command
+                acts.submitTaskAsync().catch(ex => {
+                    acts.channel.appendLine("**** " + ex + " ****");
+                });
+            });
     }
 }
 export const extensionhelper = new ExtensionHelper();

--- a/src/xsite/AtCoder.ts
+++ b/src/xsite/AtCoder.ts
@@ -108,6 +108,96 @@ class AtCoder implements XSite {
     { id: 4065, language: "Cython (0.29.16)", xextension: user1 },
     { id: 4066, language: "Sed (4.4)", xextension: user1 },
     { id: 4067, language: "Vim (8.2.0460)", xextension: user1 },
+    { id: 5001, language: "C++ 20 (gcc 12.2)", xextension: cpp},
+    { id: 5002, language: "Go (go 1.20.6)", xextension: go},
+    { id: 5003, language: "C# 11.0 (.NET 7.0.7)", xextension: user1},
+    { id: 5004, language: "Kotlin (KotlinJVM 1.8.20)", xextension: user1},
+    { id: 5005, language: "Java (OpenJDK 17)", xextension: java},
+    { id: 5006, language: "Nim (Nim 1.6.14)", xextension: user1},
+    { id: 5007, language: "V (V 0.4)", xextension: user1},
+    { id: 5008, language: "Zig (Zig 0.10.1)", xextension: user1},
+    { id: 5009, language: "JavaScript (Node.js 18.16.1)", xextension: javascript},
+    { id: 5010, language: "JavaScript (Deno 1.35.1)", xextension: javascript},
+    { id: 5011, language: "R (GNU R 4.2.1)", xextension: user1},
+    { id: 5012, language: "D (DMD 2.104.0)", xextension: user1},
+    { id: 5013, language: "D (LDC 1.32.2)", xextension: user1},
+    { id: 5014, language: "Swift (swift 5.8.1)", xextension: user1},
+    { id: 5015, language: "Dart (Dart 3.0.5)", xextension: user1},
+    { id: 5016, language: "PHP (php 8.2.8)", xextension: user1},
+    { id: 5017, language: "C (gcc 12.2.0)", xextension: cc},
+    { id: 5018, language: "Ruby (ruby 3.2.2)", xextension: user1},
+    { id: 5019, language: "Crystal (Crystal 1.9.1)", xextension: user1},
+    { id: 5020, language: "Brainfuck (bf 20041219)", xextension: user1},
+    { id: 5021, language: "F# 7.0 (.NET 7.0.7)", xextension: user1},
+    { id: 5022, language: "Julia (Julia 1.9.2)", xextension: user1},
+    { id: 5023, language: "Bash (bash 5.2.2)", xextension: user1},
+    { id: 5024, language: "Text (cat 8.32)", xextension: user1},
+    { id: 5025, language: "Haskell (GHC 9.4.5)", xextension: user1},
+    { id: 5026, language: "Fortran (gfortran 12.2)", xextension: user1},
+    { id: 5027, language: "Lua (LuaJIT 2.1.0-beta3)", xextension: user1},
+    { id: 5028, language: "C++ 23 (gcc 12.2)", xextension: cpp},
+    { id: 5029, language: "Common Lisp (SBCL 2.3.6)", xextension: user1},
+    { id: 5030, language: "COBOL (Free) (GnuCOBOL 3.1.2)", xextension: user1},
+    { id: 5031, language: "C++ 23 (Clang 16.0.6)", xextension: cpp},
+    { id: 5032, language: "Zsh (Zsh 5.9)", xextension: user1},
+    { id: 5033, language: "SageMath (SageMath 9.5)", xextension: python},
+    { id: 5034, language: "Sed (GNU sed 4.8)", xextension: user1},
+    { id: 5035, language: "bc (bc 1.07.1)", xextension: user1},
+    { id: 5036, language: "dc (dc 1.07.1)", xextension: user1},
+    { id: 5037, language: "Perl (perl 5.34)", xextension: user1},
+    { id: 5038, language: "AWK (GNU Awk 5.0.1)", xextension: user1},
+    { id: 5039, language: "なでしこ (cnako3 3.4.20)", xextension: user1},
+    { id: 5040, language: "Assembly x64 (NASM 2.15.05)", xextension: user1},
+    { id: 5041, language: "Pascal (fpc 3.2.2)", xextension: user1},
+    { id: 5042, language: "C# 11.0 AOT (.NET 7.0.7)", xextension: user1},
+    { id: 5043, language: "Lua (Lua 5.4.6)", xextension: user1},
+    { id: 5044, language: "Prolog (SWI-Prolog 9.0.4)", xextension: user1},
+    { id: 5045, language: "PowerShell (PowerShell 7.3.1)", xextension: user1},
+    { id: 5046, language: "Scheme (Gauche 0.9.12)", xextension: user1},
+    { id: 5047, language: "Scala 3.3.0 (Scala Native 0.4.14)", xextension: user1},
+    { id: 5048, language: "Visual Basic 16.9 (.NET 7.0.7)", xextension: user1},
+    { id: 5049, language: "Forth (gforth 0.7.3)", xextension: user1},
+    { id: 5050, language: "Clojure (babashka 1.3.181)", xextension: user1},
+    { id: 5051, language: "Erlang (Erlang 26.0.2)", xextension: user1},
+    { id: 5052, language: "TypeScript 5.1 (Deno 1.35.1)", xextension: typescript},
+    { id: 5053, language: "C++ 17 (gcc 12.2)", xextension: cpp},
+    { id: 5054, language: "Rust (rustc 1.70.0)", xextension: user1},
+    { id: 5055, language: "Python (CPython 3.11.4)", xextension: python},
+    { id: 5056, language: "Scala (Dotty 3.3.0)", xextension: user1},
+    { id: 5057, language: "Koka (koka 2.4.0)", xextension: user1},
+    { id: 5058, language: "TypeScript 5.1 (Node.js 18.16.1)", xextension: typescript},
+    { id: 5059, language: "OCaml (ocamlopt 5.0.0)", xextension: user1},
+    { id: 5060, language: "Raku (Rakudo 2023.06)", xextension: user1},
+    { id: 5061, language: "Vim (vim 9.0.0242)", xextension: user1},
+    { id: 5062, language: "Emacs Lisp (Native Compile) (GNU Emacs 28.2)", xextension: user1},
+    { id: 5063, language: "Python (Mambaforge / CPython 3.10.10)", xextension: python},
+    { id: 5064, language: "Clojure (clojure 1.11.1)", xextension: user1},
+    { id: 5065, language: "プロデル (mono版プロデル 1.9.1182)", xextension: user1},
+    { id: 5066, language: "ECLiPSe (ECLiPSe 7.1_13)", xextension: user1},
+    { id: 5067, language: "Nibbles (literate form) (nibbles 1.01)", xextension: user1},
+    { id: 5068, language: "Ada (GNAT 12.2)", xextension: user1},
+    { id: 5069, language: "jq (jq 1.6)", xextension: user1},
+    { id: 5070, language: "Cyber (Cyber v0.2-Latest)", xextension: user1},
+    { id: 5071, language: "Carp (Carp 0.5.5)", xextension: user1},
+    { id: 5072, language: "C++ 17 (Clang 16.0.6)", xextension: cpp},
+    { id: 5073, language: "C++ 20 (Clang 16.0.6)", xextension: cpp},
+    { id: 5074, language: "LLVM IR (Clang 16.0.6)", xextension: user1},
+    { id: 5075, language: "Emacs Lisp (Byte Compile) (GNU Emacs 28.2)", xextension: user1},
+    { id: 5076, language: "Factor (Factor 0.98)", xextension: user1},
+    { id: 5077, language: "D (GDC 12.2)", xextension: user1},
+    { id: 5078, language: "Python (PyPy 3.10-v7.3.12)", xextension: python},
+    { id: 5079, language: "Whitespace (whitespacers 1.0.0)", xextension: user1},
+    { id: 5080, language: "><> (fishr 0.1.0)", xextension: user1},
+    { id: 5081, language: "ReasonML (reason 3.9.0)", xextension: user1},
+    { id: 5082, language: "Python (Cython 0.29.34)", xextension: python},
+    { id: 5083, language: "Octave (GNU Octave 8.2.0)", xextension: user1},
+    { id: 5084, language: "Haxe (JVM) (Haxe 4.3.1)", xextension: user1},
+    { id: 5085, language: "Elixir (Elixir 1.15.2)", xextension: user1},
+    { id: 5086, language: "Mercury (Mercury 22.01.6)", xextension: user1},
+    { id: 5087, language: "Seed7 (Seed7 3.2.1)", xextension: user1},
+    { id: 5088, language: "Emacs Lisp (No Compile) (GNU Emacs 28.2)", xextension: user1},
+    { id: 5089, language: "Unison (Unison M5b)", xextension: user1},
+    { id: 5090, language: "COBOL (GnuCOBOL(Fixed) 3.1.2)", xextension: user1},
   ];
   public readonly acliburl = "https://github.com/atcoder/ac-library/archive/refs/heads/master.zip";
   public get xextension() {
@@ -395,6 +485,66 @@ class AtCoder implements XSite {
     json.atcoder.task = atcoder.task;
     json.atcoder.extension = atcoder.extension;
     json.atcoder.language = atcoder.language;
+  }
+
+  public async filterXLanguagesAsync(xlanguages: XLanguage[]) {
+    // get agent
+    const agent = superagent.agent();
+
+    // login get
+    this.loginurl = "https://atcoder.jp/login?continue=https%3A%2F%2Fatcoder.jp%2F&lang=ja";
+    acts.channel.appendLine(`[${acts.timestamp()}] atcoder.login_get:`);
+    const res1 = await agent
+      .get(this.loginurl)
+      .proxy(acts.proxy)
+      .catch(res => {
+        throw `ERROR: ${acts.responseToMessage(res)}`;
+      });
+    acts.channel.appendLine(`[${acts.timestamp()}] -> ${res1.status}`);
+
+    // login post
+    acts.channel.appendLine(`[${acts.timestamp()}] atcoder.login_post:`);
+    const $ = cheerio.load(res1.text);
+    const csrf_token = $("input").val();
+    const res2 = await agent
+      .post(this.loginurl)
+      .proxy(acts.proxy)
+      .set("Content-Type", "application/x-www-form-urlencoded")
+      .send({
+        username: this.username,
+        password: this.password,
+        csrf_token: csrf_token,
+      })
+      .catch(res => {
+        throw `ERROR: ${acts.responseToMessage(res)}`;
+      });
+    acts.channel.appendLine(`[${acts.timestamp()}] -> ${res2.status}`);
+
+    // check login
+    if (res2.text.indexOf(`ようこそ、${this.username} さん。`) < 0) {
+      throw `ERROR: atcoder login failed, userame="${this.username}", password="********", csrf_token="${csrf_token}"`;
+    }
+
+    // get language ids
+    this.submiturl = `https://atcoder.jp/contests/${this.contest}/submit`;
+    acts.channel.appendLine(`[${acts.timestamp()}] atcoder.check_valid_language_ids:`);
+    const response = await agent
+        .get(this.submiturl)
+        .proxy(acts.proxy)
+        .catch(res => {
+            throw `ERROR: ${acts.responseToMessage(res)}`;
+        });
+    acts.channel.appendLine(`[${acts.timestamp()}] -> ${response.status}`);
+    
+    const $submitpage = cheerio.load(response.text);
+    const languageIds = $submitpage(`#select-lang-${this.task} select.form-control`)
+        .find('option')
+        .toArray()
+        .flatMap(val => $submitpage(val).attr('value') ? $submitpage(val).attr('value') : []);
+    if (languageIds.length === 0) {
+      throw 'ERROR: failed to get language ids';
+    }
+    return xlanguages.filter(val => languageIds.includes(val.id.toString()));
   }
 }
 export const atcoder = new AtCoder();


### PR DESCRIPTION
ジャッジアップデート（ https://img.atcoder.jp/file/language-update/language-list.html ）に対応するため、選択中のtaskに対してsubmit時に可能な言語のリストを取得して表示する機能を追加しました。

C, C++, Go, Java, JavaScript, Python, TypeScriptのコードに関して、

1. 新しいジャッジが適用されるtaskでsubmitを行う際に新しい言語のみが選択肢に表れ、選択すると正常に提出が行われること
2. 古いジャッジが適用されるtaskでsubmitを行う際に古い言語のみが選択肢に表れ、選択すると正常に提出が行われること

を確認しました。

ご確認いただければ幸いです。
（実装方針に問題があればご指摘いただきたいです。）